### PR TITLE
removing submodule helm/x509-certificate-exporter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "helm/x509-certificate-exporter"]
-	path = helm/x509-certificate-exporter
-	url = https://github.com/enix/x509-certificate-exporter.git


### PR DESCRIPTION
no longer needed. was unable to deploy from the submodule so created https://github.com/app-sre/x509-certificate-exporter-fork instead